### PR TITLE
Tracing attempt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,15 @@ repository = "https://github.com/memoryleak47/slotted-egraphs/"
 [features]
 explanations = []
 checks = []
+tracing = ["tracing/max_level_trace", "tracing/release_max_level_trace"]
+# ??? no_tracing = ["tracing/max_level_debug", "tracing/release_max_level_off"]
 
 [package.metadata.docs.rs]
 features = ["explanations"]
 
 [dependencies]
 fnv = "1.0.7"
+tracing  = { version = "0.1", features = ["attributes"] }
 
 [dev-dependencies]
 symbol_table = { version = "0.3", features = ["global"]}

--- a/src/egraph/mod.rs
+++ b/src/egraph/mod.rs
@@ -304,6 +304,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         self.proven_get_group_compatible_variants(enode).into_iter().map(|pnode| pnode.elem).collect()
     }
 
+    #[instrument(level = "trace", skip_all)]
     pub(crate) fn get_group_compatible_weak_variants(&self, enode: &L) -> HashSet<L> {
         let set = self.get_group_compatible_variants(enode);
         let mut shapes = HashSet::default();

--- a/src/egraph/rebuild.rs
+++ b/src/egraph/rebuild.rs
@@ -112,6 +112,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         self.touched_class(from.id);
     }
 
+    #[instrument(level = "trace", skip_all)]
     pub(crate) fn rebuild(&mut self) {
         if CHECKS { self.check(); }
         while let Some(sh) = self.pending.iter().cloned().next() {

--- a/src/explain/mod.rs
+++ b/src/explain/mod.rs
@@ -30,6 +30,7 @@ pub use mock::*;
 
 #[cfg(feature = "explanations")]
 impl<L: Language, N: Analysis<L>> EGraph<L, N> {
+    #[instrument(level = "trace", skip_all)]
     pub fn explain_equivalence(&mut self, t1: RecExpr<L>, t2: RecExpr<L>) -> ProvenEq {
         let i1 = self.add_syn_expr(t1);
         let i2 = self.add_syn_expr(t2);

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -17,6 +17,7 @@ pub struct Extractor<L: Language, CF: CostFunction<L>> {
 }
 
 impl<L: Language, CF: CostFunction<L>> Extractor<L, CF> {
+    #[instrument(level = "trace", skip_all)]
     pub fn new<N: Analysis<L>>(eg: &EGraph<L, N>, cost_fn: CF) -> Self {
         if CHECKS {
             eg.check();
@@ -62,6 +63,7 @@ impl<L: Language, CF: CostFunction<L>> Extractor<L, CF> {
         Self { map }
     }
 
+    #[instrument(level = "trace", skip_all)]
     pub fn extract<N: Analysis<L>>(&self, i: &AppliedId, eg: &EGraph<L, N>) -> RecExpr<L> {
         let i = eg.find_applied_id(i);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,3 +60,5 @@ use group::*;
 
 mod run;
 pub use run::*;
+
+pub(crate) use tracing::instrument;

--- a/src/rewrite/ematch.rs
+++ b/src/rewrite/ematch.rs
@@ -11,6 +11,7 @@ struct State {
     partial_slotmap: SlotMap,
 }
 
+#[instrument(level = "trace", skip_all)]
 pub fn ematch_all<L: Language, N: Analysis<L>>(eg: &EGraph<L, N>, pattern: &Pattern<L>) -> Vec<Subst> {
     let mut out = Vec::new();
     for i in eg.ids() {
@@ -39,6 +40,10 @@ fn ematch_impl<L: Language, N: Analysis<L>>(pattern: &Pattern<L>, st: State, i: 
         Pattern::ENode(n, children) => {
             let mut out = Vec::new();
             for nn in eg.enodes_applied(&i) {
+                let d = std::mem::discriminant(n);
+                let dd = std::mem::discriminant(&nn);
+                if d != dd { continue };
+
                 'nodeloop: for n2 in eg.get_group_compatible_weak_variants(&nn) {
                     if CHECKS {
                         assert_eq!(&nullify_app_ids(n), n);

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -45,14 +45,16 @@ fn any_to_t<T: Any>(t: Box<dyn Any>) -> T {
 
 /// Applies each given rewrite rule to the E-Graph once.
 /// Returns an indicator for whether the e-graph changed as a result.
+#[instrument(level = "trace", skip_all)]
 pub fn apply_rewrites<L: Language, N: Analysis<L>>(eg: &mut EGraph<L, N>, rewrites: &[Rewrite<L, N>]) -> bool {
+    use tracing::trace;
     let prog = eg.progress();
-    
+
     let ts: Vec<Box<dyn Any>> = rewrites.iter().map(|rw| (*rw.searcher)(eg)).collect();
     for (rw, t) in rewrites.iter().zip(ts.into_iter()) {
         (*rw.applier)(t, eg);
     }
-    
+
     prog != eg.progress()
 }
 


### PR DESCRIPTION
Instruments the library with the `tracing` crate to help with profiling. There is an overhead unless features such as `tracing/max_level_debug` or `tracing/release_max_level_off` are enabled, but I could figure out how to fight with the `Cargo.toml` to enable toggling these (I think that conflicts with the other features requested by the `tracing` feature).