### PR TITLE
Trace more things

### DIFF
--- a/src/egraph/add.rs
+++ b/src/egraph/add.rs
@@ -14,6 +14,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         self.add_syn(n)
     }
 
+    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub fn add_syn(&mut self, enode: L) -> AppliedId {
         let enode = self.synify_enode(enode);
 
@@ -69,6 +70,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     }
 
 
+    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub fn add(&mut self, enode: L) -> AppliedId {
         self.add_internal(self.shape(&enode))
     }

--- a/src/egraph/rebuild.rs
+++ b/src/egraph/rebuild.rs
@@ -250,6 +250,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         }
     }
 
+    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(in crate::egraph) fn handle_congruence(&mut self, pc1: ProvenContains<L>) {
         let (sh, _) = self.shape(&pc1.node.elem);
         let pc2 = self.pc_from_shape(&sh);

--- a/src/explain/wrapper/contains.rs
+++ b/src/explain/wrapper/contains.rs
@@ -40,6 +40,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         }
     }
 
+    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(crate) fn refl_pc(&self, i: Id) -> ProvenContains<L> {
         let identity = self.mk_syn_identity_applied_id(i);
         let n = self.get_syn_node(&identity);
@@ -55,6 +56,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     }
 
     // "finds" both the node & the id to be "up-to-date".
+    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(crate) fn pc_find(&self, pc: &ProvenContains<L>) -> ProvenContains<L> {
         ProvenContains {
             node: self.proven_proven_pre_shape(&pc.node),

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -49,10 +49,14 @@ fn any_to_t<T: Any>(t: Box<dyn Any>) -> T {
 pub fn apply_rewrites<L: Language, N: Analysis<L>>(eg: &mut EGraph<L, N>, rewrites: &[Rewrite<L, N>]) -> bool {
     let prog = eg.progress();
 
+    let search_span = tracing::trace_span!("search").entered();
     let ts: Vec<Box<dyn Any>> = rewrites.iter().map(|rw| (*rw.searcher)(eg)).collect();
+    search_span.exit();
+    let apply_span = tracing::trace_span!("apply").entered();
     for (rw, t) in rewrites.iter().zip(ts.into_iter()) {
         (*rw.applier)(t, eg);
     }
+    apply_span.exit();
 
     prog != eg.progress()
 }


### PR DESCRIPTION
Remaining problem, I don't know how to easily feature gate stuff like:
```rust
    let search_span = tracing::trace_span!("search").entered();
    // [ ... ]
    search_span.exit();
```
Maybe with a generic wrapper function that does entered/exit or nothing.
It's kind of anoying to feature gate tracing ourselves in general, knowing that the tracing crate has built-in features to make tracing a no-op ...