### PR TITLE
Perf: Use inline collections and smaller types for some structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ slotted-egraphs-derive = { path = "slotted-egraphs-derive" }
 tracing = { version = "0.1", features = ["attributes"], optional = true }
 symbol_table = { version = "0.3", features = ["global"] }
 rustc-hash = "2.1.1"
+vec-collections = "0.4.3"
 
 [dev-dependencies]
 divan = { version = "2.8.1", package = "codspeed-divan-compat" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tracing = { version = "0.1", features = ["attributes"], optional = true }
 symbol_table = { version = "0.3", features = ["global"] }
 rustc-hash = "2.1.1"
 vec-collections = "0.4.3"
+smallvec = "1.14.0"
 
 [dev-dependencies]
 divan = { version = "2.8.1", package = "codspeed-divan-compat" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,6 @@ smallvec = "1.14.0"
 divan = { version = "2.8.1", package = "codspeed-divan-compat" }
 rand = "0.8.5"
 
-# [profile.release]
-# debug = true # for profiling. todo: is there a 
-
 [[bench]]
 name = "sdql"
 harness = false

--- a/slotted-egraphs-derive/src/lib.rs
+++ b/slotted-egraphs-derive/src/lib.rs
@@ -149,7 +149,7 @@ pub fn define_language(input: TokenStream1) -> TokenStream1 {
             }
 
             #[cfg_attr(feature = "trace", tracing::instrument(name = "Lang::slots", level = "trace", skip_all))]
-            fn slots(&self) -> slotted_egraphs::HashSet<Slot> {
+            fn slots(&self) -> slotted_egraphs::SmallHashSet<Slot> {
                 match self {
                     #(#slots_arms),*
                 }

--- a/src/egraph/add.rs
+++ b/src/egraph/add.rs
@@ -1,3 +1,5 @@
+use vec_collections::AbstractVecSet;
+
 use crate::*;
 
 // syntactic add:
@@ -215,12 +217,16 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
 
 impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     // TODO make the public API auto "fresh" slots.
-    pub fn alloc_empty_eclass(&mut self, _slots: &HashSet<Slot>) -> Id {
+    pub fn alloc_empty_eclass(&mut self, _slots: &SmallHashSet<Slot>) -> Id {
         panic!("Can't use alloc_empty_eclass if explanations are enabled!");
     }
 
     #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
-    pub(in crate::egraph) fn alloc_eclass(&mut self, slots: &HashSet<Slot>, syn_enode: L) -> Id {
+    pub(in crate::egraph) fn alloc_eclass(
+        &mut self,
+        slots: &SmallHashSet<Slot>,
+        syn_enode: L,
+    ) -> Id {
         let c_id = Id(self.unionfind_len()); // Pick the next unused Id.
 
         let syn_slots = syn_enode.slots();

--- a/src/egraph/check.rs
+++ b/src/egraph/check.rs
@@ -1,3 +1,5 @@
+use vec_collections::AbstractVecSet;
+
 use crate::*;
 
 impl<L: Language, N: Analysis<L>> EGraph<L, N> {

--- a/src/egraph/rebuild.rs
+++ b/src/egraph/rebuild.rs
@@ -6,7 +6,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     fn record_redundancy_witness(
         &mut self,
         i: Id,
-        cap: &HashSet<Slot>,
+        cap: &SmallHashSet<Slot>,
         #[allow(unused)] proof: ProvenEq,
     ) {
         if CHECKS {
@@ -51,7 +51,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
 
     // We expect `from` to be on the lhs of this equation.
     #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
-    pub(crate) fn shrink_slots(&mut self, from: &AppliedId, cap: &HashSet<Slot>, proof: ProvenEq) {
+    pub(crate) fn shrink_slots(&mut self, from: &AppliedId, cap: &SmallHashSet<Slot>, proof: ProvenEq) {
         #[cfg(feature = "explanations")]
         if CHECKS {
             assert_eq!(from.id, proof.l.id);
@@ -68,7 +68,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
             let m_inv = from.m.inverse();
 
             // cap :: set slots(from.id)
-            let new_cap: HashSet<Slot> = cap.iter().map(|x| m_inv[*x]).collect();
+            let new_cap: SmallHashSet<Slot> = cap.iter().map(|x| m_inv[*x]).collect();
 
             (from.id, new_cap)
         };

--- a/src/egraph/rebuild.rs
+++ b/src/egraph/rebuild.rs
@@ -51,7 +51,12 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
 
     // We expect `from` to be on the lhs of this equation.
     #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
-    pub(crate) fn shrink_slots(&mut self, from: &AppliedId, cap: &SmallHashSet<Slot>, proof: ProvenEq) {
+    pub(crate) fn shrink_slots(
+        &mut self,
+        from: &AppliedId,
+        cap: &SmallHashSet<Slot>,
+        proof: ProvenEq,
+    ) {
         #[cfg(feature = "explanations")]
         if CHECKS {
             assert_eq!(from.id, proof.l.id);

--- a/src/egraph/union.rs
+++ b/src/egraph/union.rs
@@ -168,9 +168,14 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         }
     }
 
-    fn assert_ty(&self, m: &SlotMap, keys: &HashSet<Slot>, values: &HashSet<Slot>) {
-        assert!(m.keys().is_subset(&keys));
-        assert!(m.values().is_subset(&values));
+    fn assert_ty(
+        &self,
+        m: &SlotMap,
+        keys: &SmallHashSet<Slot>,
+        values: &SmallHashSet<Slot>,
+    ) {
+        assert!(m.keys().is_subset(keys));
+        assert!(m.values().is_subset(values));
     }
 
     // moves everything from `from` to `to`.

--- a/src/egraph/union.rs
+++ b/src/egraph/union.rs
@@ -168,12 +168,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         }
     }
 
-    fn assert_ty(
-        &self,
-        m: &SlotMap,
-        keys: &SmallHashSet<Slot>,
-        values: &SmallHashSet<Slot>,
-    ) {
+    fn assert_ty(&self, m: &SlotMap, keys: &SmallHashSet<Slot>, values: &SmallHashSet<Slot>) {
         assert!(m.keys().is_subset(keys));
         assert!(m.values().is_subset(values));
     }

--- a/src/explain/proof.rs
+++ b/src/explain/proof.rs
@@ -179,7 +179,7 @@ impl TransitivityProof {
 pub(crate) fn alpha_normalize<L: Language>(n: &L) -> L {
     let (sh, bij) = n.weak_shape();
     if CHECKS {
-        let all_slots: HashSet<_> = sh.all_slot_occurrences().into_iter().collect();
+        let all_slots: SmallHashSet<_> = sh.all_slot_occurrences().into_iter().collect();
         assert!(&bij.values().is_disjoint(&all_slots));
     }
     sh.apply_slotmap(&bij)

--- a/src/explain/proof.rs
+++ b/src/explain/proof.rs
@@ -220,7 +220,7 @@ impl CongruenceProof {
 }
 
 impl Equation {
-    pub fn slots(&self) -> HashSet<Slot> {
+    pub fn slots(&self) -> SmallHashSet<Slot> {
         &self.l.slots() | &self.r.slots()
     }
 

--- a/src/explain/wrapper/perm.rs
+++ b/src/explain/wrapper/perm.rs
@@ -106,8 +106,8 @@ impl Permutation for ProvenPerm {
 impl ProvenPerm {
     pub(crate) fn identity(
         #[allow(unused)] i: Id,
-        slots: &HashSet<Slot>,
-        #[allow(unused)] syn_slots: &HashSet<Slot>,
+        slots: &SmallHashSet<Slot>,
+        #[allow(unused)] syn_slots: &SmallHashSet<Slot>,
         #[allow(unused)] reg: ProofRegistry,
     ) -> Self {
         let map = Perm::identity(slots);

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -44,7 +44,7 @@ impl<P: Permutation> Group<P> {
         Self::new(identity, HashSet::default())
     }
 
-    pub fn orbit(&self, s: Slot) -> HashSet<Slot> {
+    pub fn orbit(&self, s: Slot) -> SmallHashSet<Slot> {
         build_ot(s, &self.identity, &self.generators())
             .keys()
             .cloned()

--- a/src/group/tst.rs
+++ b/src/group/tst.rs
@@ -43,7 +43,7 @@ fn flip(n: usize, x: usize, y: usize) -> Perm {
 
 fn check_group(generators: impl IntoIterator<Item = Perm>) {
     let generators: HashSet<Perm> = generators.into_iter().collect();
-    let omega: HashSet<_> = generators.iter().next().unwrap().values();
+    let omega: SmallHashSet<_> = generators.iter().next().unwrap().values();
     let identity = SlotMap::identity(&omega);
     let l = Group::new(&identity, generators.clone()).all_perms();
     let r = enrich(generators);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@ pub type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 #[doc(hidden)]
 pub type HashSet<T> = rustc_hash::FxHashSet<T>;
 
+pub type SmallHashSet<T> = vec_collections::VecSet<[T; 5]>;
+pub use vec_collections::AbstractVecSet;
+
 pub use symbol_table::GlobalSymbol as Symbol;
 
 // Whether to enable invariant-checks.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 #[doc(hidden)]
 pub type HashSet<T> = rustc_hash::FxHashSet<T>;
 
-pub type SmallHashSet<T> = vec_collections::VecSet<[T; 5]>;
+pub type SmallHashSet<T> = vec_collections::VecSet<[T; 8]>;
 pub use vec_collections::AbstractVecSet;
 
 pub use symbol_table::GlobalSymbol as Symbol;

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -6,16 +6,16 @@ use std::fmt::*;
 /// Slots represent Variable names.
 ///
 /// Internally, they are just a number.
-pub struct Slot(u64);
+pub struct Slot(u32);
 
 // %4 = 0 -> numeric
 // %4 = 1 -> fresh
 // %4 = 2 -> named
 // %4 = 3 -> <unused>
 struct SlotTable {
-    fresh_idx: u64,
+    fresh_idx: u32,
     named_vec: Vec<String>,
-    named_map: HashMap<String, u64>,
+    named_map: HashMap<String, u32>,
 }
 
 thread_local! {
@@ -40,18 +40,18 @@ impl Slot {
 
     /// Generates a numeric slot like `$42`
     pub fn numeric(u: u32) -> Slot {
-        Slot(u as u64 * 4)
+        Slot(u * 4)
     }
 
     /// Generates a named slot like `$xyz`
     pub fn named(s: &str) -> Slot {
-        if let Ok(x) = s.parse::<u64>() {
+        if let Ok(x) = s.parse::<u32>() {
             return Slot(x * 4); // numeric
         }
 
         SLOT_TABLE.with_borrow_mut(|tab| {
             if s.starts_with("f") {
-                if let Ok(x) = s[1..].parse::<u64>() {
+                if let Ok(x) = s[1..].parse::<u32>() {
                     let out = x * 4 + 1;
                     if tab.fresh_idx <= out {
                         tab.fresh_idx = out + 4;
@@ -64,7 +64,7 @@ impl Slot {
                 return Slot(*x); // cached named
             }
 
-            let i = tab.named_vec.len() as u64;
+            let i = tab.named_vec.len() as u32;
             let i = 4 * i + 2;
             tab.named_vec.push(s.to_string());
             tab.named_map.insert(s.to_string(), i);

--- a/src/slotmap.rs
+++ b/src/slotmap.rs
@@ -73,10 +73,10 @@ impl SlotMap {
         self.map.iter().map(|(_, y)| y)
     }
 
-    pub fn keys(&self) -> HashSet<Slot> {
+    pub fn keys(&self) -> SmallHashSet<Slot> {
         self.iter().map(|(x, _)| x).collect()
     }
-    pub fn values(&self) -> HashSet<Slot> {
+    pub fn values(&self) -> SmallHashSet<Slot> {
         self.iter().map(|(_, y)| y).collect()
     }
     pub fn keys_vec(&self) -> Vec<Slot> {
@@ -155,7 +155,7 @@ impl SlotMap {
         out
     }
 
-    pub fn identity(set: &HashSet<Slot>) -> SlotMap {
+    pub fn identity(set: &SmallHashSet<Slot>) -> SlotMap {
         let mut out = SlotMap::new();
         for &x in set {
             out.insert(x, x);
@@ -163,7 +163,7 @@ impl SlotMap {
         out
     }
 
-    pub fn bijection_from_fresh_to(set: &HashSet<Slot>) -> SlotMap {
+    pub fn bijection_from_fresh_to(set: &SmallHashSet<Slot>) -> SlotMap {
         let mut out = SlotMap::new();
         for &x in set {
             out.insert(Slot::fresh(), x);

--- a/src/slotmap.rs
+++ b/src/slotmap.rs
@@ -1,3 +1,5 @@
+use smallvec::SmallVec;
+
 use crate::*;
 use std::ops::Index;
 
@@ -15,7 +17,7 @@ pub(crate) type Bijection = SlotMap;
 pub struct SlotMap {
     // if (l, r) in map, then there is no (l, r') in map. Each key is uniquely contained.
     // Also: map is sorted by their keys.
-    map: Vec<(Slot, Slot)>,
+    map: SmallVec<[(Slot, Slot); 10]>,
 }
 
 impl SlotMap {

--- a/src/types.rs
+++ b/src/types.rs
@@ -62,7 +62,7 @@ impl AppliedId {
     }
 
     #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
-    pub fn slots(&self) -> HashSet<Slot> {
+    pub fn slots(&self) -> SmallHashSet<Slot> {
         self.m.values()
     }
 

--- a/tests/entry.rs
+++ b/tests/entry.rs
@@ -24,7 +24,7 @@ pub use array::*;
 
 mod misc;
 
-pub fn singleton_set<T: Eq + Hash>(t: T) -> HashSet<T> {
+pub fn singleton_set<T: Eq + Hash + Ord>(t: T) -> SmallHashSet<T> {
     [t].into_iter().collect()
 }
 

--- a/tests/lambda/step.rs
+++ b/tests/lambda/step.rs
@@ -115,7 +115,7 @@ fn lam_subst(re: &RecExpr<Lambda>, x: Slot, t: &RecExpr<Lambda>) -> RecExpr<Lamb
     }
 }
 
-fn lam_free_variables(re: &RecExpr<Lambda>) -> HashSet<Slot> {
+fn lam_free_variables(re: &RecExpr<Lambda>) -> SmallHashSet<Slot> {
     match &re.node {
         Lambda::Lam(Bind { slot: x, .. }) => {
             let [b] = &*re.children else { panic!() };


### PR DESCRIPTION
Here, we use
- `smallvec` for `SlotMap`, because those are mostly small
- `vec_collections::HashSet` for vector-backed sets of `Slot`s
- `u32` for Slots instead of `u64`, since 1B slots should be more than enough
for a small performance gain (around 20% on my machine).