### PR TITLE
Fix all "unused" warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,15 +24,15 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
       - name: Build
-        run: cargo build --verbose
+        run: cargo build
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test
       - name: Run tests with `checks`
-        run: cargo test --verbose --features checks
+        run: cargo test --features checks
       - name: Run tests with `explanations`
-        run: cargo test --verbose --features explanations
+        run: cargo test --features explanations
       - name: Run tests with `checks` and `explanations`
-        run: cargo test --verbose --features checks,explanations
+        run: cargo test --features checks,explanations
 
   formatting:
     name: cargo fmt

--- a/benches/sdql.rs
+++ b/benches/sdql.rs
@@ -6,7 +6,7 @@ fn main() {
 }
 
 #[divan::bench(sample_count = 10)]
-fn batax_v7_csr_dense_unfused_esat() {
+fn batax_v7_csr_dense_unfused_esat() -> Report {
     let prog = "
 (lambda $var_01
   (lambda $var_02
@@ -35,14 +35,13 @@ fn batax_v7_csr_dense_unfused_esat() {
     let prog: RecExpr<Sdql> = RecExpr::parse(&prog).unwrap();
     let mut eg = EGraph::<Sdql, SdqlKind>::new();
     let rewrites = sdql_rules();
-    let id1 = eg.add_syn_expr(prog.clone());
-    let report = run_eqsat(&mut eg, rewrites, 30, 5, move |egraph| Ok(()));
+    let _id1 = eg.add_syn_expr(prog.clone());
+    let report = run_eqsat(&mut eg, rewrites, 30, 5, move |_egraph| Ok(()));
+    report
 }
 
 mod sdql {
     use slotted_egraphs::*;
-
-    use crate::*;
 
     define_language! {
         pub enum Sdql {
@@ -87,7 +86,7 @@ mod sdql {
     }
 
     impl Analysis<Sdql> for SdqlKind {
-        fn make(eg: &slotted_egraphs::EGraph<Sdql, Self>, enode: &Sdql) -> Self {
+        fn make(_eg: &slotted_egraphs::EGraph<Sdql, Self>, enode: &Sdql) -> Self {
             let mut out = SdqlKind {
                 might_be_vector: false,
                 might_be_dict: false,
@@ -326,7 +325,7 @@ mod sdql {
         Rewrite::new("sum-sum-vert-fuse-2", pat, outpat)
     }
 
-    fn get_sum_vert_fuse_1() -> SdqlRewrite {
+    fn _get_sum_vert_fuse_1() -> SdqlRewrite {
         let pat = "(get (sum $k $v ?R (sing (var $k) ?body1)) ?body2)";
         let outpat = "(let $k ?body2 (let $v (get ?R (var $k)) ?body1))";
         Rewrite::new("get-sum-vert-fuse-1", pat, outpat)
@@ -340,7 +339,7 @@ mod sdql {
         )
     }
 
-    fn sum_range_2() -> SdqlRewrite {
+    fn _sum_range_2() -> SdqlRewrite {
         Rewrite::new_if(
             "sum-range-2",
             "(sum $k $v (range ?st ?en) (ifthen (eq (var $k) ?key) ?body))",

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -35,7 +35,7 @@ impl Debug for AppliedId {
 }
 
 impl<L: Language, N: Analysis<L>> Debug for EGraph<L, N> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, _f: &mut Formatter<'_>) -> Result {
         todo!()
     }
 }

--- a/src/egraph/analysis.rs
+++ b/src/egraph/analysis.rs
@@ -7,6 +7,6 @@ pub trait Analysis<L: Language>: Eq + Clone {
 }
 
 impl<L: Language> Analysis<L> for () {
-    fn make(eg: &EGraph<L, Self>, _: &L) {}
-    fn merge(l: (), r: ()) -> () {}
+    fn make(_eg: &EGraph<L, Self>, _: &L) {}
+    fn merge(_l: (), _r: ()) -> () {}
 }

--- a/src/egraph/check.rs
+++ b/src/egraph/check.rs
@@ -67,6 +67,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
 
         // redundancy-check for leaders.
         // TODO add a similar check for followers, using unionfind_get.
+        #[allow(unused)]
         for (i, c) in &self.classes {
             if !self.is_alive(*i) {
                 continue;
@@ -106,7 +107,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
             assert_eq!(usages[&i], c.usages);
         }
 
-        for (i, c) in &self.classes {
+        for (_, c) in &self.classes {
             for p in c.group.all_perms() {
                 p.check();
             }

--- a/src/egraph/mod.rs
+++ b/src/egraph/mod.rs
@@ -318,8 +318,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
             return out;
         }
 
-        let n = enode.elem.applied_id_occurrences().len();
-
         let groups: Vec<Vec<ProvenPerm>> = enode
             .elem
             .applied_id_occurrences()
@@ -395,6 +393,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         app
     }
 
+    #[cfg(feature = "explanations")]
     pub(crate) fn semify_enode(&self, enode: L) -> L {
         enode.map_applied_ids(|app| self.semify_app_id(app))
     }

--- a/src/egraph/union.rs
+++ b/src/egraph/union.rs
@@ -24,12 +24,14 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         from_pat: &Pattern<L>,
         to_pat: &Pattern<L>,
         subst: &Subst,
-        justification: Option<String>,
+        #[allow(unused)] justification: Option<String>,
     ) -> bool {
         let a = pattern_subst(self, from_pat, subst);
         let b = pattern_subst(self, to_pat, subst);
 
+        #[allow(unused)]
         let syn_a = self.synify_app_id(a.clone());
+        #[allow(unused)]
         let syn_b = self.synify_app_id(b.clone());
 
         let proof = ghost!(self.prove_explicit(&syn_a, &syn_b, justification));
@@ -49,7 +51,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         &mut self,
         l: &AppliedId,
         r: &AppliedId,
-        proof: ProvenEq,
+        #[allow(unused)] proof: ProvenEq,
     ) -> bool {
         // normalize inputs
         let pai_l = self.proven_find_applied_id(&l);
@@ -172,7 +174,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     }
 
     // moves everything from `from` to `to`.
-    fn move_to(&mut self, from: &AppliedId, to: &AppliedId, proof: ProvenEq) {
+    fn move_to(&mut self, from: &AppliedId, to: &AppliedId, #[allow(unused)] proof: ProvenEq) {
         if CHECKS {
             assert_eq!(from.slots(), to.slots());
             #[cfg(feature = "explanations")]
@@ -213,7 +215,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         // who updates the usages? raw_add_to_class & raw_remove_from_class do that.
 
         let from_nodes = self.classes.get(&from.id).unwrap().nodes.clone();
-        let from_id = self.mk_sem_identity_applied_id(from.id);
         for (sh, psn) in from_nodes {
             self.raw_remove_from_class(from.id, sh.clone());
             // if `sh` contains redundant slots, these won't be covered by 'map'.

--- a/src/explain/front.rs
+++ b/src/explain/front.rs
@@ -265,7 +265,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
 
         // we want to prove l2_id = r_id.
         let l2_id = l_id.apply_slotmap_fresh(&map);
-        let l2_node = self.get_syn_node(&l2_id);
 
         self.lift_sem_congruence(l2_id, r_id, &child_proofs)
     }

--- a/src/explain/mod.rs
+++ b/src/explain/mod.rs
@@ -45,10 +45,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         }
 
         let pai1 = self.proven_find_applied_id(&i1);
-        let ProvenAppliedId {
-            elem: l1,
-            proof: prf1,
-        } = &pai1;
+        let ProvenAppliedId { elem: l1, proof: _ } = &pai1;
 
         let pai2 = self.proven_find_applied_id(&i2);
         let ProvenAppliedId {
@@ -64,7 +61,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         let bij = l2.m.compose(&l1.m.inverse());
         let symmetry_prf = &self.classes[&id].group.proven_contains(&bij).unwrap();
         let ProvenAppliedId {
-            elem: l1,
+            elem: _,
             proof: prf1,
         } = self.chain_pai_pp(&pai1, symmetry_prf);
 

--- a/src/explain/proof.rs
+++ b/src/explain/proof.rs
@@ -43,17 +43,6 @@ pub struct ProvenEqRaw {
 }
 
 impl ProvenEqRaw {
-    pub(crate) fn null() -> ProvenEq {
-        let app_id = AppliedId::new(Id(0), Default::default());
-        Arc::new(ProvenEqRaw {
-            eq: Equation {
-                l: app_id.clone(),
-                r: app_id.clone(),
-            },
-            proof: Proof::Explicit(ExplicitProof(None)),
-        })
-    }
-
     pub fn equ(&self) -> Equation {
         (**self).clone()
     }
@@ -82,7 +71,7 @@ impl Hash for ProvenEqRaw {
 }
 
 impl ExplicitProof {
-    pub fn check(&self, eq: &Equation, reg: &ProofRegistry) -> ProvenEq {
+    pub(crate) fn check(&self, eq: &Equation, reg: &ProofRegistry) -> ProvenEq {
         let eq = eq.clone();
         let proof = Proof::Explicit(self.clone());
         reg.insert(Arc::new(ProvenEqRaw { eq, proof }))
@@ -90,7 +79,7 @@ impl ExplicitProof {
 }
 
 impl ReflexivityProof {
-    pub fn check(&self, eq: &Equation, reg: &ProofRegistry) -> ProvenEq {
+    pub(crate) fn check(&self, eq: &Equation, reg: &ProofRegistry) -> ProvenEq {
         assert_eq!(eq.l, eq.r);
 
         let eq = eq.clone();
@@ -100,7 +89,7 @@ impl ReflexivityProof {
 }
 
 impl SymmetryProof {
-    pub fn check(&self, eq: &Equation, reg: &ProofRegistry) -> ProvenEq {
+    pub(crate) fn check(&self, eq: &Equation, reg: &ProofRegistry) -> ProvenEq {
         let SymmetryProof(x) = self;
 
         let flipped = Equation {
@@ -116,7 +105,7 @@ impl SymmetryProof {
 }
 
 impl TransitivityProof {
-    pub fn check(&self, eq: &Equation, reg: &ProofRegistry) -> ProvenEq {
+    pub(crate) fn check(&self, eq: &Equation, reg: &ProofRegistry) -> ProvenEq {
         let TransitivityProof(eq1, eq2) = self;
 
         let mut theta1 = {

--- a/src/explain/show.rs
+++ b/src/explain/show.rs
@@ -8,11 +8,6 @@ impl ProvenEqRaw {
         self.show_impl(&|i| eg.get_syn_expr(i).to_string())
     }
 
-    /// Prints the proof steps, using the internal [AppliedId]s to represent terms.
-    fn to_string_applied_ids(&self) -> String {
-        self.show_impl(&|i| format!("{i:?}"))
-    }
-
     // internals:
     pub(crate) fn show_impl(&self, f: &impl Fn(&AppliedId) -> String) -> String {
         let mut map = Default::default();
@@ -30,7 +25,7 @@ impl ProvenEqRaw {
 
     fn subproofs(&self) -> Vec<&ProvenEq> {
         match self.proof() {
-            Proof::Explicit(ExplicitProof(j)) => vec![],
+            Proof::Explicit(ExplicitProof(_)) => vec![],
             Proof::Reflexivity(ReflexivityProof) => vec![],
             Proof::Symmetry(SymmetryProof(x)) => vec![x],
             Proof::Transitivity(TransitivityProof(x1, x2)) => vec![x1, x2],
@@ -59,7 +54,7 @@ impl ProvenEqRaw {
                 Proof::Transitivity(TransitivityProof(_, _)) => {
                     format!("transitivity({}, {})", ids[0], ids[1])
                 }
-                Proof::Congruence(CongruenceProof(xs)) => {
+                Proof::Congruence(CongruenceProof(_)) => {
                     let s = ids.join(", ");
                     format!("congruence({s})")
                 }

--- a/src/explain/wrapper/applied_id.rs
+++ b/src/explain/wrapper/applied_id.rs
@@ -9,7 +9,7 @@ pub(crate) struct ProvenAppliedId {
 }
 
 impl<L: Language, N: Analysis<L>> EGraph<L, N> {
-    pub(crate) fn check_pai(&self, pai: &ProvenAppliedId) {
+    pub(crate) fn check_pai(&self, #[allow(unused)] pai: &ProvenAppliedId) {
         #[cfg(feature = "explanations")]
         {
             assert_eq!(pai.proof.r.id, pai.elem.id);
@@ -20,6 +20,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
 
     #[cfg(feature = "explanations")]
     // if we use the proof to go backwards from `elem`, where do we end up?
+    #[allow(unused)]
     pub(crate) fn pai_source_applied_id(&self, pai: &ProvenAppliedId) -> AppliedId {
         todo!()
     }
@@ -67,7 +68,11 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     }
 
     // doesn't do anything if explanations are off.
-    pub(crate) fn chain_pai_eq(&self, pai: &ProvenAppliedId, peq: ProvenEq) -> ProvenAppliedId {
+    pub(crate) fn chain_pai_eq(
+        &self,
+        pai: &ProvenAppliedId,
+        #[allow(unused)] peq: ProvenEq,
+    ) -> ProvenAppliedId {
         ProvenAppliedId {
             elem: pai.elem.clone(),
 

--- a/src/explain/wrapper/contains.rs
+++ b/src/explain/wrapper/contains.rs
@@ -83,6 +83,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         out
     }
 
+    #[allow(unused)]
     pub(crate) fn chain_pc_eq(&self, start: &ProvenContains<L>, eq: ProvenEq) -> ProvenContains<L> {
         ProvenContains {
             node: start.node.clone(),
@@ -152,7 +153,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
             if CHECKS {
                 assert_eq!(prf_a.len(), prf_b.len());
             }
-            let n = prf_a.len();
 
             let mut vec = Vec::new();
             for (pa, pb) in prf_a.iter().zip(prf_b.iter()) {

--- a/src/explain/wrapper/node.rs
+++ b/src/explain/wrapper/node.rs
@@ -29,6 +29,7 @@ impl<L: Language> Hash for ProvenNode<L> {
 impl<L: Language> ProvenNode<L> {
     // checks that `proofs` brings us from `base` to `elem`.
     #[cfg(feature = "explanations")]
+    #[allow(unused)]
     pub(crate) fn check_base(&self, base: &L) {
         let l = base.applied_id_occurrences();
         let r = self.elem.applied_id_occurrences();
@@ -56,7 +57,7 @@ impl<L: Language> ProvenNode<L> {
 }
 
 impl<L: Language, N: Analysis<L>> EGraph<L, N> {
-    pub(crate) fn check_pn(&self, pn: &ProvenNode<L>) {
+    pub(crate) fn check_pn(&self, #[allow(unused)] pn: &ProvenNode<L>) {
         #[cfg(feature = "explanations")]
         {
             let a = &pn.proofs;
@@ -70,6 +71,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
 
     #[cfg(feature = "explanations")]
     // If we take the `proofs` to go backward from `elem`, where do we land?
+    #[allow(unused)]
     pub(crate) fn pn_source_node(&self, pn: &ProvenNode<L>) -> L {
         todo!()
     }
@@ -107,7 +109,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         let mut app_ids_mut: Vec<&mut AppliedId> = pn.elem.applied_id_occurrences_mut();
 
         #[cfg(feature = "explanations")]
-        let mut proofs_mut: &mut [ProvenEq] = &mut pn.proofs;
+        let proofs_mut: &mut [ProvenEq] = &mut pn.proofs;
 
         for i in 0..n {
             let old_app_id: &mut AppliedId = app_ids_mut[i];

--- a/src/explain/wrapper/perm.rs
+++ b/src/explain/wrapper/perm.rs
@@ -105,14 +105,16 @@ impl Permutation for ProvenPerm {
 
 impl ProvenPerm {
     pub(crate) fn identity(
-        i: Id,
+        #[allow(unused)] i: Id,
         slots: &HashSet<Slot>,
-        syn_slots: &HashSet<Slot>,
-        reg: ProofRegistry,
+        #[allow(unused)] syn_slots: &HashSet<Slot>,
+        #[allow(unused)] reg: ProofRegistry,
     ) -> Self {
         let map = Perm::identity(slots);
 
+        #[cfg(feature = "explanations")]
         let identity = SlotMap::identity(syn_slots);
+        #[cfg(feature = "explanations")]
         let app_id = AppliedId::new(i, identity);
         #[cfg(feature = "explanations")]
         let prf = prove_reflexivity(&app_id, &reg);
@@ -123,10 +125,6 @@ impl ProvenPerm {
             #[cfg(feature = "explanations")]
             reg,
         }
-    }
-
-    fn to_string(&self) -> String {
-        format!("{:?}", (&self.elem, ghost!(&**self.proof)))
     }
 
     pub(crate) fn check(&self) {

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -86,7 +86,7 @@ impl<L: Language, CF: CostFunction<L>> Extractor<L, CF> {
         RecExpr { node: l, children }
     }
 
-    pub fn get_best_cost<N: Analysis<L>>(&self, i: &AppliedId, eg: &EGraph<L, N>) -> CF::Cost {
+    pub fn get_best_cost<N: Analysis<L>>(&self, i: &AppliedId, _eg: &EGraph<L, N>) -> CF::Cost {
         self.map[&i.id].1.clone()
     }
 }

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -102,6 +102,7 @@ impl<P: Permutation> Group<P> {
         }
     }
 
+    #[cfg(feature = "explanations")]
     pub fn proven_contains(&self, p: &Perm) -> Option<P> {
         match &self.next {
             None if p.iter().all(|(x, y)| x == y) => Some(self.identity.clone()),

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -20,7 +20,7 @@ pub trait LanguageChildren: Debug + Clone + Hash + Eq {
     fn to_syntax(&self) -> Vec<SyntaxElem>;
     fn from_syntax(_: &[SyntaxElem]) -> Option<Self>;
 
-    fn weak_shape_impl(&mut self, m: &mut (SlotMap, u32)) {
+    fn weak_shape_impl(&mut self, _m: &mut (SlotMap, u32)) {
         todo!()
     }
 }
@@ -136,7 +136,7 @@ macro_rules! bare_language_child {
                 }
             }
 
-            fn weak_shape_impl(&mut self, m: &mut (SlotMap, u32)) {}
+            fn weak_shape_impl(&mut self, _m: &mut (SlotMap, u32)) {}
         }
         )*
     }

--- a/tests/entry.rs
+++ b/tests/entry.rs
@@ -37,7 +37,7 @@ pub fn id<L: Language>(s: &str, eg: &mut EGraph<L>) -> AppliedId {
     out
 }
 
-pub fn term<L: Language>(s: &str, eg: &mut EGraph<L>) -> RecExpr<L> {
+pub fn term<L: Language>(s: &str) -> RecExpr<L> {
     let re = RecExpr::parse(s).unwrap();
     re
 }
@@ -54,8 +54,10 @@ pub fn equate<L: Language>(s1: &str, s2: &str, eg: &mut EGraph<L>) {
 
 pub fn explain<L: Language>(s1: &str, s2: &str, eg: &mut EGraph<L>) {
     eg.check();
-    let s1 = term(s1, eg);
-    let s2 = term(s2, eg);
+    #[allow(unused)]
+    let s1: RecExpr<L> = term(s1);
+    #[allow(unused)]
+    let s2: RecExpr<L> = term(s2);
     #[cfg(feature = "explanations")]
     println!("{}", eg.explain_equivalence(s1, s2).to_string(eg));
     eg.check();

--- a/tests/lambda/build.rs
+++ b/tests/lambda/build.rs
@@ -1,5 +1,3 @@
-use crate::lambda::*;
-
 // The Y combinator.
 pub fn y() -> String {
     let a = format!("(lam $0 (app (var $1) (app (var $0) (var $0))))");

--- a/tests/lambda/mod.rs
+++ b/tests/lambda/mod.rs
@@ -7,7 +7,6 @@ mod my_cost;
 pub use my_cost::*;
 
 mod tst;
-pub use tst::*;
 
 mod normalize;
 pub use normalize::*;

--- a/tests/lambda/step.rs
+++ b/tests/lambda/step.rs
@@ -72,7 +72,7 @@ fn lam_subst(re: &RecExpr<Lambda>, x: Slot, t: &RecExpr<Lambda>) -> RecExpr<Lamb
             } else {
                 let f = lam_free_variables(t);
 
-                let mut y: Slot = *y;
+                let y: Slot = *y;
                 let mut b: RecExpr<Lambda> = b.clone();
 
                 if f.contains(&y) {
@@ -88,7 +88,7 @@ fn lam_subst(re: &RecExpr<Lambda>, x: Slot, t: &RecExpr<Lambda>) -> RecExpr<Lamb
                     };
 
                     b = lam_subst(&b, y, &y2_node);
-                    y = y2;
+                    // y = y2;
                 }
                 RecExpr {
                     node: re.node.clone(),

--- a/tests/lambda/tst.rs
+++ b/tests/lambda/tst.rs
@@ -1,5 +1,3 @@
-use crate::lambda::*;
-
 #[macro_export]
 macro_rules! unpack_tests {
     ($R:ty) => {

--- a/tests/rise/mod.rs
+++ b/tests/rise/mod.rs
@@ -7,7 +7,6 @@ mod rewrite;
 pub use rewrite::*;
 
 mod my_cost;
-pub use my_cost::*;
 
 define_language! {
     pub enum Rise {

--- a/tests/rise/my_cost.rs
+++ b/tests/rise/my_cost.rs
@@ -1,7 +1,5 @@
 use crate::*;
 
-use std::cmp::Ordering;
-
 impl CostFunction<Rise> for AstSizeNoLet {
     type Cost = MyCost;
 

--- a/tests/rise/rewrite.rs
+++ b/tests/rise/rewrite.rs
@@ -221,12 +221,12 @@ fn separate_dot_hv_simplified() -> Rewrite<Rise> {
 }
 
 // subst using extraction
+#[allow(unused)]
 fn beta_extr() -> Rewrite<Rise> {
     let pat = Pattern::parse("(app (lam $1 ?b) ?t)").unwrap();
     let s = Slot::numeric(1);
 
     let a = pat.clone();
-    let a2 = pat.clone();
 
     let rt: RewriteT<Rise, (), Vec<(Subst, RecExpr<Rise>)>> = RewriteT {
         searcher: Box::new(move |eg| {
@@ -259,7 +259,6 @@ fn beta_extr_direct() -> Rewrite<Rise> {
     let s = Slot::numeric(1);
 
     let a = pat.clone();
-    let a2 = pat.clone();
 
     let rt: RewriteT<Rise, (), ()> = RewriteT {
         searcher: Box::new(|_| ()),

--- a/tests/rise/tst.rs
+++ b/tests/rise/tst.rs
@@ -215,8 +215,8 @@ fn small3() {
     let eg: &mut EGraph<Rise> = &mut EGraph::new();
     let x1 = id("x1", eg);
     let x2 = id("x2", eg);
-    let x1x3 = term("(app x1 x3)", eg);
-    let x2x3 = term("(app x2 x3)", eg);
+    let x1x3: RecExpr<Rise> = term("(app x1 x3)");
+    let x2x3: RecExpr<Rise> = term("(app x2 x3)");
     eg.union(&x1, &x2);
     eg.dump();
     dbg!(&x1x3);


### PR DESCRIPTION
This PR fixes *all* warnings emitted by cargo. In CI, warnings are also denied.

This includes
- all features and combinations
- all tests
- all benches.

This was my approach:
- If an argument `arg` in a method / function was unused (either because it's only used in `explanations` or not at all), I renamed it to `_arg`.
- Some "unused" code just needed `#cfg[feature = "explanations"]`.
- If a method / function was completely unused, I commented it out. These might be worth discussing, i.e., whether we could completely remove them.
- If some `let` binding etc was unused, I commented it out. These could maybe also be removed entirely?
- If an import was unused, I deleted it.

I wonder if there's a cleaner way to separate `explanations` from the rest, especially considering those `_arg`s...