### PR TITLE
chore: remove tracing feature and dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,6 @@ repository = "https://github.com/memoryleak47/slotted-egraphs/"
 [features]
 explanations = []
 checks = []
-trace = [
-  "tracing/max_level_trace",
-  "tracing/release_max_level_trace",
-  "tracing",
-]
 
 [package.metadata.docs.rs]
 features = ["explanations"]
@@ -21,7 +16,6 @@ features = ["explanations"]
 [dependencies]
 #slotted-egraphs-derive = "=0.0.34"
 slotted-egraphs-derive = { path = "slotted-egraphs-derive" }
-tracing = { version = "0.1", features = ["attributes"], optional = true }
 symbol_table = { version = "0.3", features = ["global"] }
 rustc-hash = "2.1.1"
 vec-collections = "0.4.3"

--- a/slotted-egraphs-derive/src/lib.rs
+++ b/slotted-egraphs-derive/src/lib.rs
@@ -85,21 +85,18 @@ pub fn define_language(input: TokenStream1) -> TokenStream1 {
 
         impl Language for #name {
             // mut:
-            #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", skip_all))]
             fn all_slot_occurrences_mut(&mut self) -> Vec<&mut Slot> {
                 match self {
                     #(#all_slot_occurrences_mut_arms),*
                 }
             }
 
-            #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", skip_all))]
             fn public_slot_occurrences_mut(&mut self) -> Vec<&mut Slot> {
                 match self {
                     #(#public_slot_occurrences_mut_arms),*
                 }
             }
 
-            #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", skip_all))]
             fn applied_id_occurrences_mut(&mut self) -> Vec<&mut AppliedId> {
                 match self {
                     #(#applied_id_occurrences_mut_arms),*
@@ -108,21 +105,18 @@ pub fn define_language(input: TokenStream1) -> TokenStream1 {
 
 
             // immut:
-            #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", skip_all))]
             fn all_slot_occurrences(&self) -> Vec<Slot> {
                 match self {
                     #(#all_slot_occurrences_arms),*
                 }
             }
 
-            #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", skip_all))]
             fn public_slot_occurrences(&self) -> Vec<Slot> {
                 match self {
                     #(#public_slot_occurrences_arms),*
                 }
             }
 
-            #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", skip_all))]
             fn applied_id_occurrences(&self) -> Vec<&AppliedId> {
                 match self {
                     #(#applied_id_occurrences_arms),*
@@ -148,14 +142,12 @@ pub fn define_language(input: TokenStream1) -> TokenStream1 {
                 }
             }
 
-            #[cfg_attr(feature = "trace", tracing::instrument(name = "Lang::slots", level = "trace", skip_all))]
             fn slots(&self) -> slotted_egraphs::SmallHashSet<Slot> {
                 match self {
                     #(#slots_arms),*
                 }
             }
 
-            #[cfg_attr(feature = "trace", tracing::instrument(name = "Lang::weak_shape_inplace", level = "trace", skip_all))]
             fn weak_shape_inplace(&mut self) -> slotted_egraphs::SlotMap {
                 let m = &mut (slotted_egraphs::SlotMap::new(), 0);
                 match self {
@@ -165,7 +157,9 @@ pub fn define_language(input: TokenStream1) -> TokenStream1 {
                 m.0.inverse()
             }
         }
-    }.to_token_stream().into()
+    }
+    .to_token_stream()
+    .into()
 }
 
 fn produce_all_slot_occurrences_mut(name: &Ident, v: &Variant) -> TokenStream2 {

--- a/src/egraph/add.rs
+++ b/src/egraph/add.rs
@@ -16,7 +16,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         self.add_syn(n)
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub fn add_syn(&mut self, enode: L) -> AppliedId {
         #[cfg(not(feature = "explanations"))]
         {
@@ -81,19 +80,16 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         self.add(n)
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub fn add(&mut self, enode: L) -> AppliedId {
         self.add_internal(self.shape_called_from_add(enode))
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn shape_called_from_add(&self, enode: L) -> (L, Bijection) {
         self.shape(&enode)
     }
 
     // self.add(x) = y implies that x.slots() is a superset of y.slots().
     // x.slots() - y.slots() are redundant slots.
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(in crate::egraph) fn add_internal(&mut self, t: (L, SlotMap)) -> AppliedId {
         if let Some(x) = self.lookup_internal(&t) {
             return x;
@@ -144,7 +140,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
 
 impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     // returns a syn applied id.
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn mk_singleton_class(&mut self, syn_enode: L) -> AppliedId {
         let old_slots = syn_enode.slots();
 
@@ -165,14 +160,12 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         self.mk_syn_applied_id(i, fresh_to_old)
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn rebuild_called_from_add(&mut self) {
         self.rebuild();
     }
 
     // adds (sh, bij) to the eclass `id`.
     // TODO src_id should be optional!
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(in crate::egraph) fn raw_add_to_class(
         &mut self,
         id: Id,
@@ -198,7 +191,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         }
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(in crate::egraph) fn raw_remove_from_class(&mut self, id: Id, sh: L) -> ProvenSourceNode {
         let opt_psn = self.classes.get_mut(&id).unwrap().nodes.remove(&sh);
         let opt_id = self.hashcons.remove(&sh);
@@ -222,7 +214,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         panic!("Can't use alloc_empty_eclass if explanations are enabled!");
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(in crate::egraph) fn alloc_eclass(
         &mut self,
         slots: &SmallHashSet<Slot>,

--- a/src/egraph/find.rs
+++ b/src/egraph/find.rs
@@ -75,7 +75,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         self.proven_proven_find_enode(&pn)
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(crate) fn proven_proven_find_enode(&self, enode: &ProvenNode<L>) -> ProvenNode<L> {
         self.chain_pn_map(enode, |_, pai| self.proven_proven_find_applied_id(&pai))
     }

--- a/src/egraph/mod.rs
+++ b/src/egraph/mod.rs
@@ -283,7 +283,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         self.proven_proven_pre_shape(&e).weak_shape()
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(crate) fn proven_proven_pre_shape(&self, e: &ProvenNode<L>) -> ProvenNode<L> {
         let e = self.proven_proven_find_enode(e);
         self.proven_proven_get_group_compatible_variants(&e)
@@ -309,7 +308,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     // {f(c[$0, $1], c[$1, $0]),
     //  f(c[$0, $1], c[$0, $1])}
     // This is what get_group_compatible_weak_variants would return.
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(crate) fn proven_proven_get_group_compatible_variants(
         &self,
         enode: &ProvenNode<L>,
@@ -365,7 +363,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
             .collect()
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(crate) fn get_group_compatible_weak_variants(&self, enode: &L) -> HashSet<L> {
         let set = self.get_group_compatible_variants(enode);
         let mut shapes = HashSet::default();
@@ -450,7 +447,6 @@ impl PendingType {
 // {1,2} x {3} x {4,5} -> (1,3,4), (1,3,5), (2,3,4), (2,3,5)
 // TODO re-enable use<...> when it's stabilized.
 // fn cartesian<'a, T>(input: &'a [Vec<T>]) -> impl Iterator<Item=Vec<&'a T>> /*+ use<'a, T>*/ + '_ {
-#[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
 fn cartesian<T>(input: &[Vec<T>]) -> impl Iterator<Item = Vec<&T>> + '_ {
     let n = input.len();
     let mut indices = vec![0; n];

--- a/src/egraph/rebuild.rs
+++ b/src/egraph/rebuild.rs
@@ -50,7 +50,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     }
 
     // We expect `from` to be on the lhs of this equation.
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(crate) fn shrink_slots(
         &mut self,
         from: &AppliedId,
@@ -133,7 +132,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         self.touched_class(from.id, PendingType::Full);
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(crate) fn rebuild(&mut self) {
         if CHECKS {
             self.check();
@@ -233,7 +231,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     }
 
     // finds self-symmetries caused by the e-node `src_id`.
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn determine_self_symmetries(&mut self, src_id: Id) {
         let pc1 = self.pc_from_src_id(src_id);
 
@@ -283,7 +280,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         }
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(in crate::egraph) fn handle_congruence(&mut self, pc1: ProvenContains<L>) {
         let (sh, _) = self.shape(&pc1.node.elem);
         let pc2 = self.pc_from_shape(&sh);
@@ -293,7 +289,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     }
 
     // upon touching an e-class, you need to update all usages of it.
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(crate) fn touched_class(&mut self, i: Id, pending_ty: PendingType) {
         for sh in &self.classes[&i].usages {
             let v = self.pending.entry(sh.clone()).or_insert(pending_ty);
@@ -301,7 +296,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         }
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(crate) fn pc_from_shape(&self, sh: &L) -> ProvenContains<L> {
         let i = self
             .hashcons

--- a/src/egraph/union.rs
+++ b/src/egraph/union.rs
@@ -18,7 +18,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         self.union_instantiations(&a, &b, &subst, j)
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub fn union_instantiations(
         &mut self,
         from_pat: &Pattern<L>,
@@ -41,12 +40,10 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         out
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn rebuild_called_from_union_instantiations(&mut self) {
         self.rebuild();
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(in crate::egraph) fn union_internal(
         &mut self,
         l: &AppliedId,

--- a/src/explain/mod.rs
+++ b/src/explain/mod.rs
@@ -35,7 +35,6 @@ pub use mock::*;
 
 #[cfg(feature = "explanations")]
 impl<L: Language, N: Analysis<L>> EGraph<L, N> {
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub fn explain_equivalence(&mut self, t1: RecExpr<L>, t2: RecExpr<L>) -> ProvenEq {
         let i1 = self.add_syn_expr(t1);
         let i2 = self.add_syn_expr(t2);

--- a/src/explain/wrapper/contains.rs
+++ b/src/explain/wrapper/contains.rs
@@ -55,7 +55,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         }
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub(crate) fn pc_from_src_id(&self, i: Id) -> ProvenContains<L> {
         self.pc_find(&self.refl_pc(i))
     }

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -17,7 +17,6 @@ pub struct Extractor<L: Language, CF: CostFunction<L>> {
 }
 
 impl<L: Language, CF: CostFunction<L>> Extractor<L, CF> {
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub fn new<N: Analysis<L>>(eg: &EGraph<L, N>, cost_fn: CF) -> Self {
         if CHECKS {
             eg.check();
@@ -70,7 +69,6 @@ impl<L: Language, CF: CostFunction<L>> Extractor<L, CF> {
         Self { map }
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub fn extract<N: Analysis<L>>(&self, i: &AppliedId, eg: &EGraph<L, N>) -> RecExpr<L> {
         let i = eg.find_applied_id(i);
 

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -65,7 +65,6 @@ impl<P: Permutation> Group<P> {
     }
 
     // Should be very rarely called.
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub fn all_perms(&self) -> HashSet<P> {
         match &self.next {
             None => [self.identity.clone()].into_iter().collect(),

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -271,7 +271,6 @@ pub trait Language: Debug + Clone + Hash + Eq {
     // generated methods:
 
     #[doc(hidden)]
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn private_slot_occurrences_mut(&mut self) -> Vec<&mut Slot> {
         let public = self.public_slot_occurrences();
         let mut out = self.all_slot_occurrences_mut();
@@ -280,7 +279,6 @@ pub trait Language: Debug + Clone + Hash + Eq {
     }
 
     #[doc(hidden)]
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn private_slot_occurrences(&self) -> Vec<Slot> {
         let public = self.public_slot_occurrences();
         let mut out = self.all_slot_occurrences();
@@ -289,13 +287,11 @@ pub trait Language: Debug + Clone + Hash + Eq {
     }
 
     #[doc(hidden)]
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn private_slots(&self) -> SmallHashSet<Slot> {
         self.private_slot_occurrences().into_iter().collect()
     }
 
     #[doc(hidden)]
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn map_applied_ids(&self, mut f: impl FnMut(AppliedId) -> AppliedId) -> Self {
         let mut c = self.clone();
         for x in c.applied_id_occurrences_mut() {
@@ -307,10 +303,6 @@ pub trait Language: Debug + Clone + Hash + Eq {
     // TODO m.values() might collide with your private slot names.
     // Should we rename our private slots to be safe?
     #[doc(hidden)]
-    #[cfg_attr(
-        feature = "trace",
-        instrument(name = "Lang::apply_slotmap_partial", level = "trace", skip_all)
-    )]
     fn apply_slotmap_partial(&self, m: &SlotMap) -> Self {
         let mut prv = vec![].into();
         if CHECKS {
@@ -333,10 +325,6 @@ pub trait Language: Debug + Clone + Hash + Eq {
 
     #[track_caller]
     #[doc(hidden)]
-    #[cfg_attr(
-        feature = "trace",
-        instrument(name = "Lang::apply_slotmap", level = "trace", skip_all)
-    )]
     fn apply_slotmap(&self, m: &SlotMap) -> Self {
         if CHECKS {
             assert!(
@@ -348,10 +336,6 @@ pub trait Language: Debug + Clone + Hash + Eq {
     }
 
     #[doc(hidden)]
-    #[cfg_attr(
-        feature = "trace",
-        instrument(name = "Lang::apply_slotmap_fresh", level = "trace", skip_all)
-    )]
     fn apply_slotmap_fresh(&self, m: &SlotMap) -> Self {
         let mut prv = vec![].into();
         if CHECKS {
@@ -373,7 +357,6 @@ pub trait Language: Debug + Clone + Hash + Eq {
     }
 
     #[doc(hidden)]
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn ids(&self) -> Vec<Id> {
         self.applied_id_occurrences()
             .into_iter()
@@ -386,7 +369,6 @@ pub trait Language: Debug + Clone + Hash + Eq {
     // - bij.slots() == n.slots(). Note that these would also include redundant slots.
     // - sh is the lexicographically lowest equivalent version of n, reachable by bijective renaming of slots (including redundant ones).
     #[doc(hidden)]
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn weak_shape(&self) -> (Self, Bijection) {
         let mut c = self.clone();
         let bij = c.weak_shape_inplace();
@@ -394,7 +376,6 @@ pub trait Language: Debug + Clone + Hash + Eq {
     }
 
     #[doc(hidden)]
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn refresh_private(&self) -> Self {
         let mut c = self.clone();
         let prv: SmallHashSet<Slot> = c.private_slot_occurrences().into_iter().collect();
@@ -406,7 +387,6 @@ pub trait Language: Debug + Clone + Hash + Eq {
     }
 
     #[doc(hidden)]
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn refresh_slots(&self, set: SmallHashSet<Slot>) -> Self {
         let mut c = self.clone();
         let fresh = SlotMap::bijection_from_fresh_to(&set).inverse();
@@ -421,7 +401,6 @@ pub trait Language: Debug + Clone + Hash + Eq {
     // refreshes private and redundant slots.
     // The public slots are given by `public`.
     #[doc(hidden)]
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn refresh_internals(&self, public: SmallHashSet<Slot>) -> Self {
         let mut c = self.clone();
         let internals = &c

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,3 @@ use group::*;
 
 mod run;
 pub use run::*;
-
-#[cfg(feature = "trace")]
-pub(crate) use tracing::instrument;

--- a/src/rewrite/ematch.rs
+++ b/src/rewrite/ematch.rs
@@ -11,7 +11,6 @@ struct State {
     partial_slotmap: SlotMap,
 }
 
-#[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
 pub fn ematch_all<L: Language, N: Analysis<L>>(
     eg: &EGraph<L, N>,
     pattern: &Pattern<L>,
@@ -29,7 +28,6 @@ pub fn ematch_all<L: Language, N: Analysis<L>>(
 }
 
 // `i` uses egraph slots instead of pattern slots.
-#[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
 fn ematch_impl<L: Language, N: Analysis<L>>(
     pattern: &Pattern<L>,
     st: State,
@@ -65,7 +63,6 @@ fn ematch_impl<L: Language, N: Analysis<L>>(
     }
 }
 
-#[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
 fn ematch_node<L: Language, N: Analysis<L>>(
     st: &State,
     eg: &EGraph<L, N>,
@@ -113,7 +110,6 @@ fn ematch_node<L: Language, N: Analysis<L>>(
     }
 }
 
-#[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
 pub(crate) fn nullify_app_ids<L: Language>(l: &L) -> L {
     let mut l = l.clone();
     for x in l.applied_id_occurrences_mut() {
@@ -122,7 +118,6 @@ pub(crate) fn nullify_app_ids<L: Language>(l: &L) -> L {
     l
 }
 
-#[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
 fn try_insert_compatible_slotmap_bij(k: Slot, v: Slot, map: &mut SlotMap) -> bool {
     if let Some(v_old) = map.get(k) {
         if v_old != v {
@@ -133,7 +128,6 @@ fn try_insert_compatible_slotmap_bij(k: Slot, v: Slot, map: &mut SlotMap) -> boo
     map.is_bijection()
 }
 
-#[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
 fn final_subst(s: State) -> Subst {
     let State {
         partial_subst: mut subst,

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -44,7 +44,6 @@ pub fn any_to_t<T: Any>(t: Box<dyn Any>) -> T {
 
 /// Applies each given rewrite rule to the E-Graph once.
 /// Returns an indicator for whether the e-graph changed as a result.
-#[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
 pub fn apply_rewrites<L: Language, N: Analysis<L>>(
     eg: &mut EGraph<L, N>,
     rewrites: &[Rewrite<L, N>],
@@ -85,7 +84,6 @@ impl<L: Language + 'static, N: Analysis<L> + 'static> Rewrite<L, N> {
         .into()
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     fn apply_substs_cond(
         substs: Vec<Subst>,
         cond: &(impl Fn(&Subst, &EGraph<L, N>) -> bool + 'static),
@@ -120,7 +118,6 @@ pub struct ProgressMeasure {
 
 impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// Computes the [ProgressMeasure] of this E-Graph.
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub fn progress(&self) -> ProgressMeasure {
         let ids = self.ids();
         ProgressMeasure {

--- a/src/rewrite/pattern.rs
+++ b/src/rewrite/pattern.rs
@@ -12,7 +12,6 @@ pub enum Pattern<L: Language> {
 }
 
 // We write this as pattern[subst] for short.
-#[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
 pub fn pattern_subst<L: Language, N: Analysis<L>>(
     eg: &mut EGraph<L, N>,
     pattern: &Pattern<L>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -51,17 +51,14 @@ impl AppliedId {
         self.apply_slotmap_partial(m)
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub fn apply_slotmap_partial(&self, m: &SlotMap) -> AppliedId {
         AppliedId::new(self.id, self.m.compose_partial(m))
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub fn apply_slotmap_fresh(&self, m: &SlotMap) -> AppliedId {
         AppliedId::new(self.id, self.m.compose_fresh(m))
     }
 
-    #[cfg_attr(feature = "trace", instrument(level = "trace", skip_all))]
     pub fn slots(&self) -> SmallHashSet<Slot> {
         self.m.values()
     }


### PR DESCRIPTION
See discussion #22.

Also worth mentioning: I've found a convenient tracing solution with [tracy](https://github.com/wolfpld/tracy) and [tracy_client](https://github.com/nagisa/rust_tracy_client), see https://github.com/memoryleak47/slotted-egraphs/issues/27#issuecomment-2772643039 for an example. So while I do see now how tracing itself *is* useful, I think we can get better results more easily by using tracy.

I will add all the necessary tracy setup in a later PR.

See also the working Bencher setup below.